### PR TITLE
chg; dev: setup.py config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,23 @@ __version__ = '1.0.0'
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+try:
+    import pypandoc
+    if path.isfile('README.rst'):
+        print("README.rst already exist.")
+        print("NOT REFRESHING README.rst")
+    else:
+        long_description = pypandoc.convert_file('README.md', 'rst')
+        with open("README.rst", "w") as f:
+            f.write(long_description)
+
+    with open('README.rst', encoding='utf-8') as f:
+        long_description = f.read()
+except Exception as e:
+    print("Error:{}:{}".format(type(e), e))
+    print("NOT REFRESHING README.rst")
+    with open('README.md', encoding='utf-8') as f:
+        long_description = f.read()
 
 # get the dependencies and installs
 with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:


### PR DESCRIPTION
this is to generate readme.rst, example here

https://test.pypi.org/project/google_images_download/

if you give me access to pypi, i can upload it with fixed readme.rst

currently i have another branch here, which contain fixed readme.rst

https://github.com/rachmadaniHaryono/google-images-download/tree/feature/release-branch

current readme (`readme.md`) can't be directly translated to rst file.

- some emoji is not registered
- syntax difference (`**`)

so for now i remove the table until @hardikvasa fix it or change the readme file to rst.

---
also @hardikvasa, if possible disable travis, or create simple python empty config for travis, so pr can be marked as succesful